### PR TITLE
Fixes: Update classMember return when status change

### DIFF
--- a/src/controllers/class.controller.js
+++ b/src/controllers/class.controller.js
@@ -93,15 +93,18 @@ class ClassController {
         classId: req.body.classId,
         userId: req.body.userId,
       };
-      const newClassMember = await ClassMember.findOneAndUpdate(
+      const classMember = await ClassMember.findOneAndUpdate(
         { ...classMemberData },
         { status: req.body.status },
+        {
+          new: true,
+        },
       );
 
       return res.status(200).json({
         status: 'success',
         data: {
-          classMember: newClassMember,
+          classMember,
         },
       });
     } catch (error) {

--- a/src/controllers/lesson.controller.js
+++ b/src/controllers/lesson.controller.js
@@ -1,7 +1,7 @@
-import Question from "../db/models/questions.model";
-import QuizResult from "../db/models/quizResults.model";
-import Lesson from "../db/models/lessons.model";
-import SubjectProgress from "../db/models/subjectProgresses.model";
+import Question from '../db/models/questions.model';
+import QuizResult from '../db/models/quizResults.model';
+import Lesson from '../db/models/lessons.model';
+import SubjectProgress from '../db/models/subjectProgresses.model';
 /**
  *Contains Lesson Controller
  *
@@ -22,15 +22,15 @@ class LessonController {
     try {
       const questions = await Question.find({ lessonId: req.params.lessonId });
       return res.status(200).json({
-        status: "success",
+        status: 'success',
         data: {
           questions,
         },
       });
     } catch (error) {
       return res.status(500).json({
-        status: "500 Internal server error",
-        error: "Error Loading questions",
+        status: '500 Internal server error',
+        error: 'Error Loading questions',
       });
     }
   }
@@ -45,22 +45,22 @@ class LessonController {
    */
   static async searchLessons(req, res) {
     try {
-      const searchEntry = req.query.searchQuery ? req.query.searchQuery : "";
-      const searchQuery = new RegExp(`.*${searchEntry}.*`, "i");
+      const searchEntry = req.query.searchQuery ? req.query.searchQuery : '';
+      const searchQuery = new RegExp(`.*${searchEntry}.*`, 'i');
       const lessons = await Lesson.find({
         $or: [{ title: searchQuery }, { content: searchQuery }],
       });
 
       return res.status(200).json({
-        status: "success",
+        status: 'success',
         data: {
           lessons,
         },
       });
     } catch (error) {
       return res.status(500).json({
-        status: "500 Internal server error",
-        error: "Error Loading lessons",
+        status: '500 Internal server error',
+        error: 'Error Loading lessons',
       });
     }
   }
@@ -101,15 +101,15 @@ class LessonController {
       const quizResult = await QuizResult.create({ ...quizResultData });
 
       return res.status(200).json({
-        status: "success",
+        status: 'success',
         data: {
           results: quizResult,
         },
       });
     } catch (error) {
       return res.status(500).json({
-        status: "500 Internal server error",
-        error: "Error saving results",
+        status: '500 Internal server error',
+        error: 'Error saving results',
       });
     }
   }
@@ -128,7 +128,7 @@ class LessonController {
         lessonId: req.params.lessonId,
         userId: req.data.id,
       });
-      if (Object.keys(req.body).includes("classId")) {
+      if (Object.keys(req.body).includes('classId')) {
         quizResult = await QuizResult.findOne({
           lessonId: req.params.lessonId,
           userId: req.data.id,
@@ -137,21 +137,21 @@ class LessonController {
       }
       if (!quizResult) {
         return res.status(404).json({
-          status: "404 error not found",
-          error: "Result not found",
+          status: '404 error not found',
+          error: 'Result not found',
         });
       }
 
       return res.status(200).json({
-        status: "success",
+        status: 'success',
         data: {
           results: quizResult,
         },
       });
     } catch (error) {
       return res.status(500).json({
-        status: "500 Internal server error",
-        error: "Error Loading tests",
+        status: '500 Internal server error',
+        error: 'Error Loading tests',
       });
     }
   }
@@ -201,7 +201,7 @@ class LessonController {
       const strength = totalScore / results.length;
 
       return res.status(200).json({
-        status: "success",
+        status: 'success',
         data: {
           lessons,
           subjectProgress,
@@ -210,8 +210,8 @@ class LessonController {
       });
     } catch (error) {
       return res.status(500).json({
-        status: "500 Internal server error",
-        error: "Error Loading lessons",
+        status: '500 Internal server error',
+        error: 'Error Loading lessons',
       });
     }
   }

--- a/src/controllers/socialLogin.controller.js
+++ b/src/controllers/socialLogin.controller.js
@@ -1,9 +1,9 @@
 import { OAuth2Client } from 'google-auth-library';
 import { config } from 'dotenv';
+import axios from 'axios';
 import Auth from '../db/models/users.model';
 import Helper from '../utils/user.utils';
 import AuthServices from '../services/auth.services';
-import axios from 'axios';
 
 config();
 /**
@@ -56,7 +56,7 @@ class AuthController {
             user: myUser,
           },
         });
-      }     
+      }
     } catch (err) {
       return res.status(500).json({
         status: '500 Internal server error',
@@ -83,14 +83,14 @@ class AuthController {
           access_token: token,
         },
       });
-      if(data){
+      if (data) {
         const response = {
           email: data.email,
-          fullName: data.last_name+' '+data.first_name,
+          fullName: `${data.last_name} ${data.first_name}`,
           isActivated: true,
           googleUserId: data.id,
         };
-        
+
         let myUser = await AuthServices.emailExist(data.email, res);
 
         // if the user does not have an account
@@ -103,7 +103,7 @@ class AuthController {
           myUser.role,
           myUser.fullName,
         );
-        
+
         return res.status(200).json({
           status: 'success',
           data: {
@@ -111,11 +111,10 @@ class AuthController {
             user: myUser,
           },
         });
-
-      } 
+      }
       return res.status(200).json({
         status: 'success',
-        data
+        data,
       });
     } catch (err) {
       return res.status(500).json({
@@ -124,6 +123,5 @@ class AuthController {
       });
     }
   }
-
 }
 export default AuthController;

--- a/src/routes/lesson.route.js
+++ b/src/routes/lesson.route.js
@@ -21,5 +21,4 @@ router.get(
 router.get('/', LessonController.searchLessons);
 router.post('/:courseId/:subjectId/subject-lessons', LessonController.getSubjectLessonsAndProgress);
 
-
 export default router;

--- a/src/test/lesson.test.js
+++ b/src/test/lesson.test.js
@@ -1,23 +1,23 @@
-import chai from "chai";
-import chaiHttp from "chai-http";
-import Sinonchai from "sinon-chai";
-import sinon from "sinon";
-import mongoose from "mongoose";
-import jwt from "jsonwebtoken";
-import app from "../index";
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import Sinonchai from 'sinon-chai';
+import sinon from 'sinon';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import app from '../index';
 // import logger from '../config';
 
-import LessonController from "../controllers/lesson.controller";
-import Question from "../db/models/questions.model";
-import QuizResult from "../db/models/quizResults.model";
-import Lesson from "../db/models/lessons.model";
+import LessonController from '../controllers/lesson.controller';
+import Question from '../db/models/questions.model';
+import QuizResult from '../db/models/quizResults.model';
+import Lesson from '../db/models/lessons.model';
 
 chai.should();
 chai.use(Sinonchai);
 chai.use(chaiHttp);
 // const { expect } = chai;
 
-describe("Classes ", () => {
+describe('Classes ', () => {
   const test_result_id = new mongoose.mongo.ObjectId();
   const user_id = new mongoose.mongo.ObjectId();
   const question_id = new mongoose.mongo.ObjectId();
@@ -25,82 +25,82 @@ describe("Classes ", () => {
   const unknown_lesson_id = new mongoose.mongo.ObjectId();
   const new_lesson = {
     _id: lesson_id,
-    subjectId: "5fc8d2a4b55ab52a40d75a54",
-    courseId: "5fc8d2a4b55ab52a40d75a54",
-    creatorId: "5fc8d2a4b55ab52a40d75a54",
-    termId: "5fc8d2a4b55ab52a40d75a54",
-    title: "lorem ipsum vicini",
+    subjectId: '5fc8d2a4b55ab52a40d75a54',
+    courseId: '5fc8d2a4b55ab52a40d75a54',
+    creatorId: '5fc8d2a4b55ab52a40d75a54',
+    termId: '5fc8d2a4b55ab52a40d75a54',
+    title: 'lorem ipsum vicini',
     content:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.",
-    videoUrl: "https://www.youtube.com/watch?v=kSdR1UIWh_s",
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.',
+    videoUrl: 'https://www.youtube.com/watch?v=kSdR1UIWh_s',
   };
   const getSubject = {
-    subjectId: "5fc8d2a4b55ab52a40d75a54",
-    courseId: "5fc8d2a4b55ab52a40d75a54",
+    subjectId: '5fc8d2a4b55ab52a40d75a54',
+    courseId: '5fc8d2a4b55ab52a40d75a54',
   };
   const getSubjectWithClas = {
-    userId: "5fc8d2a4b55ab52a40d75a54",
-    classId: "5fc8d2a4b55ab52a40d75a54",
+    userId: '5fc8d2a4b55ab52a40d75a54',
+    classId: '5fc8d2a4b55ab52a40d75a54',
   };
   const token = jwt.sign(
     {
       data: {
         id: user_id,
-        role: "5fc8cc978e28fa50986ecac9",
-        fullName: "Testing fullName",
+        role: '5fc8cc978e28fa50986ecac9',
+        fullName: 'Testing fullName',
       },
     },
-    process.env.SECRET
+    process.env.SECRET,
   );
 
   const testResultData = {
     _id: test_result_id,
     results: [
       {
-        questionId: "5fc8e7134bfe993c34a9689c",
+        questionId: '5fc8e7134bfe993c34a9689c',
         optionSelected: 0,
         correctOption: 1,
-        status: "incorrect",
+        status: 'incorrect',
       },
       {
-        questionId: "5fc8e7134bfe993c34a9689c",
+        questionId: '5fc8e7134bfe993c34a9689c',
         optionSelected: 0,
         correctOption: 1,
-        status: "incorrect",
+        status: 'incorrect',
       },
     ],
-    userId: "5fc8e7134bfe993c34a9689c",
-    classId: "5fc8e7134bfe993c34a9689c",
-    courseId: "5fc8e7134bfe993c34a9689c",
-    lessonId: "5fc8e7134bfe993c34a9689c",
-    timeSpent: "20:00:00",
+    userId: '5fc8e7134bfe993c34a9689c',
+    classId: '5fc8e7134bfe993c34a9689c',
+    courseId: '5fc8e7134bfe993c34a9689c',
+    lessonId: '5fc8e7134bfe993c34a9689c',
+    timeSpent: '20:00:00',
     numberOfCorrectAnswers: 2,
     numberOfWrongAnswers: 3,
     numberOfSkippedQuestions: 2,
     score: 2,
-    remark: "You can be better",
+    remark: 'You can be better',
   };
 
   before(async () => {
     await Question.create({
       _id: question_id,
       lessonId: lesson_id,
-      question: "Who is the president of Nigeria",
-      questionImage: "https://picsum.photos/200",
-      imagePosition: "top",
-      optionA: "Muhammed Buhari",
-      optionAImage: "https://picsum.photos/200",
-      optionB: "Da Vinci",
-      optionBImage: "https://picsum.photos/200",
-      optionC: "Donald Trump",
-      optionCImage: "https://picsum.photos/200",
-      optionD: "Will Smith",
-      optionDImage: "https://picsum.photos/200",
-      optionE: "Ayo Balogun",
-      optionEImage: "https://picsum.photos/200",
+      question: 'Who is the president of Nigeria',
+      questionImage: 'https://picsum.photos/200',
+      imagePosition: 'top',
+      optionA: 'Muhammed Buhari',
+      optionAImage: 'https://picsum.photos/200',
+      optionB: 'Da Vinci',
+      optionBImage: 'https://picsum.photos/200',
+      optionC: 'Donald Trump',
+      optionCImage: 'https://picsum.photos/200',
+      optionD: 'Will Smith',
+      optionDImage: 'https://picsum.photos/200',
+      optionE: 'Ayo Balogun',
+      optionEImage: 'https://picsum.photos/200',
       correctOption: 0,
       explanation:
-        "Muhammed Buhari is the president of the federal republic of Nigeria",
+        'Muhammed Buhari is the president of the federal republic of Nigeria',
     });
     await Lesson.create({ ...new_lesson });
   });
@@ -111,77 +111,77 @@ describe("Classes ", () => {
     await Lesson.findByIdAndDelete(lesson_id);
   });
 
-  it("should return array of question with status 200", (done) => {
+  it('should return array of question with status 200', (done) => {
     chai
       .request(app)
       .get(`/api/v1/lessons/${lesson_id}/test`)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("questions");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('questions');
         done();
       });
   });
 
-  it("should submit test result and  return array of quiz results with status 200", (done) => {
+  it('should submit test result and  return array of quiz results with status 200', (done) => {
     chai
       .request(app)
       .post(`/api/v1/lessons/${lesson_id}/save-test-results`)
-      .set("token", token)
+      .set('token', token)
       .send({ ...testResultData })
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("results");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('results');
         done();
       });
   });
 
-  it("should neither submit test result nor  return array of quiz results with status 400", (done) => {
+  it('should neither submit test result nor  return array of quiz results with status 400', (done) => {
     chai
       .request(app)
       .post(`/api/v1/lessons/${lesson_id}/save-test-results`)
-      .set("token", token)
+      .set('token', token)
       .send({ ...testResultData, timeSpent: 2 })
       .end((err, res) => {
         res.should.have.status(400);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("400 Invalid Request");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('400 Invalid Request');
         done();
       });
   });
 
-  it("should return array of quiz results with status 200", (done) => {
+  it('should return array of quiz results with status 200', (done) => {
     chai
       .request(app)
       .get(`/api/v1/lessons/${lesson_id}/get-test-results`)
-      .set("token", token)
+      .set('token', token)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("results");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('results');
         done();
       });
   });
 
-  it("should return array of quiz results related to a class with status 200", (done) => {
+  it('should return array of quiz results related to a class with status 200', (done) => {
     chai
       .request(app)
       .get(`/api/v1/lessons/${lesson_id}/get-test-results`)
-      .set("token", token)
-      .send({ classId: "5fc8e7134bfe993c34a9689c" })
+      .set('token', token)
+      .send({ classId: '5fc8e7134bfe993c34a9689c' })
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("results");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('results');
         done();
       });
   });
@@ -190,145 +190,145 @@ describe("Classes ", () => {
     chai
       .request(app)
       .get(`/api/v1/lessons/${unknown_lesson_id}/get-test-results`)
-      .set("token", token)
+      .set('token', token)
       .end((err, res) => {
         res.should.have.status(404);
-        res.body.should.be.an("object");
+        res.body.should.be.an('object');
         done();
       });
   });
 
-  it("should return array of lessons with status 200", (done) => {
+  it('should return array of lessons with status 200', (done) => {
     chai
       .request(app)
-      .get("/api/v1/lessons")
-      .query({ searchQuery: "vicini" })
+      .get('/api/v1/lessons')
+      .query({ searchQuery: 'vicini' })
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("lessons");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('lessons');
         done();
       });
   });
 
-  it("should return array of lessons even with no searchQuery, with status 200", (done) => {
+  it('should return array of lessons even with no searchQuery, with status 200', (done) => {
     chai
       .request(app)
-      .get("/api/v1/lessons")
+      .get('/api/v1/lessons')
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("lessons");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('lessons');
         done();
       });
   });
 
-  it("fakes server error", (done) => {
+  it('fakes server error', (done) => {
     const req = { body: {} };
     const res = {
       status() {},
       send() {},
     };
 
-    sinon.stub(res, "status").returnsThis();
+    sinon.stub(res, 'status').returnsThis();
 
     LessonController.loadTest(req, res);
     res.status.should.have.callCount(1);
     done();
   });
 
-  it("fakes server error", (done) => {
+  it('fakes server error', (done) => {
     const req = { body: {} };
     const res = {
       status() {},
       send() {},
     };
 
-    sinon.stub(res, "status").returnsThis();
+    sinon.stub(res, 'status').returnsThis();
 
     LessonController.saveTestResult(req, res);
     res.status.should.have.callCount(1);
     done();
   });
 
-  it("fakes server error", (done) => {
+  it('fakes server error', (done) => {
     const req = { body: {} };
     const res = {
       status() {},
       send() {},
     };
 
-    sinon.stub(res, "status").returnsThis();
+    sinon.stub(res, 'status').returnsThis();
 
     LessonController.getTestResult(req, res);
     res.status.should.have.callCount(1);
     done();
   });
 
-  it("fakes server error", (done) => {
+  it('fakes server error', (done) => {
     const req = { body: {} };
     const res = {
       status() {},
       send() {},
     };
 
-    sinon.stub(res, "status").returnsThis();
+    sinon.stub(res, 'status').returnsThis();
 
     LessonController.searchLessons(req, res);
     res.status.should.have.callCount(1);
     done();
   });
 
-  it("should return subject lessons and progress", (done) => {
+  it('should return subject lessons and progress', (done) => {
     chai
       .request(app)
       .post(
-        `/api/v1/lessons/5fc8d2a4b55ab52a40d75a54/5fc8d2a4b55ab52a40d75a54/subject-lessons`
+        '/api/v1/lessons/5fc8d2a4b55ab52a40d75a54/5fc8d2a4b55ab52a40d75a54/subject-lessons',
       )
-      .set("token", token)
+      .set('token', token)
       .send(getSubject)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("lessons");
-        res.body.data.should.have.property("subjectProgress");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('lessons');
+        res.body.data.should.have.property('subjectProgress');
         done();
       });
   });
 
-  it("should return subject lessons and progress when Class ID is sent", (done) => {
+  it('should return subject lessons and progress when Class ID is sent', (done) => {
     chai
       .request(app)
       .post(
-        `/api/v1/lessons/5fc8d2a4b55ab52a40d75a54/5fc8d2a4b55ab52a40d75a54/subject-lessons`
+        '/api/v1/lessons/5fc8d2a4b55ab52a40d75a54/5fc8d2a4b55ab52a40d75a54/subject-lessons',
       )
-      .set("token", token)
+      .set('token', token)
       .send(getSubjectWithClas)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.an("object");
-        res.body.should.have.property("status").eql("success");
-        res.body.should.have.property("data");
-        res.body.data.should.have.property("lessons");
-        res.body.data.should.have.property("subjectProgress");
+        res.body.should.be.an('object');
+        res.body.should.have.property('status').eql('success');
+        res.body.should.have.property('data');
+        res.body.data.should.have.property('lessons');
+        res.body.data.should.have.property('subjectProgress');
         done();
       });
   });
 
-  it("fakes server error", (done) => {
+  it('fakes server error', (done) => {
     const req = { body: {} };
     const res = {
       status() {},
       send() {},
     };
 
-    sinon.stub(res, "status").returnsThis();
+    sinon.stub(res, 'status').returnsThis();
 
     LessonController.getSubjectLessonsAndProgress(req, res);
     res.status.should.have.callCount(1);


### PR DESCRIPTION
### What does this PR do?
- Updated endpoint to accept, reject or retract classMember Status
- Updated classMember is returned

### Description of tasks completed
Have the following Endpoints working
`PATCH /api/v1/classes/accept-reject-class-request` headers `token: <authToken>`

### How should this be manually tested?
-  Clone this repository to your local machine
-  Run `npm install` to install node packages
-  Run `npm run dev` to start Server
-  Using Postman,  test the endpoint
-  Run `npm run test` to run unit test

![postman](https://user-images.githubusercontent.com/49147442/102069820-8e1a2e00-3dfe-11eb-8be7-5504eb9e20c3.png)



